### PR TITLE
Add KirlikSayin algorithm

### DIFF
--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -1,0 +1,241 @@
+#  Copyright 2019, Oscar Dowson and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public License,
+#  v.2.0. If a copy of the MPL was not distributed with this file, You can
+#  obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+    KirlikSayin()
+
+`KirlikSayin` implements the Kirlik & Sayın (2014) algorithm.
+
+## Supported optimizer attributes
+
+"""
+
+mutable struct KirlikSayin <: AbstractAlgorithm
+  #yI::Union{Nothing, Vector{Float64}}
+  #yN::Union{Nothing, Vector{Float64}}
+  #L::Vector{Rectangle}
+
+  #KirlikSayin() = new(nothing, nothing, Rectangle[])
+  KirlikSayin() = new()
+end
+
+#=
+MOI.supports(::KirlikSayin, ::IdealPoint) = true
+
+function MOI.get(alg::KirlikSayin, attr::IdealPoint)
+  return alg.yI
+end
+
+function MOI.set(alg::KirlikSayin, attr::IdealPoint, value)
+  alg.yI = value
+  return
+end
+
+function MOI.set(alg::KirlikSayin, attr::IdealPoint, index, value)
+  alg.yI[index] = value
+  return
+end
+
+MOI.supports(::KirlikSayin, ::NadirPoint) = true
+
+function MOI.get(alg::KirlikSayin, attr::NadirPoint)
+  return alg.yN
+end
+
+function MOI.set(alg::KirlikSayin, attr::NadirPoint, value)
+  alg.yN = value
+  return
+end
+
+function MOI.set(alg::KirlikSayin, attr::NadirPoint, index, value)
+  alg.yN[index] = value
+  return
+end
+=#
+struct Rectangle
+  l::Vector{Float64}
+  u::Vector{Float64}
+  dim::Int
+  function Rectangle(l::Vector{Float64}, u::Vector{Float64})
+    @assert length(l) == length(u) "Dimension mismatch between l and u"
+    return new(l, u, length(l))
+  end
+end
+
+function ⊆(Rᵢ::Rectangle, Rⱼ::Rectangle)
+	@assert Rᵢ.dim == Rⱼ.dim "Dimension mismatch"
+	all(Rᵢ.l .≥ Rⱼ.l) && all(Rᵢ.u .≤ Rⱼ.u)
+end
+
+function remove_rect!(L::Vector{Rectangle}, R::Rectangle)
+  ix_to_pop = []
+  for (t, Rₜ) in enumerate(L)
+    if Rₜ ⊆ R
+      push!(ix_to_pop, t)
+    end
+  end
+  # Lᵤ = L[ix_to_pop]
+  deleteat!(L, ix_to_pop)
+  # return Lᵤ
+end
+
+function split_rectangle(r::Rectangle, axis::Int, f::Float64)
+  l = [i != axis ? r.l[i] : f for i = 1:r.dim]
+  u = [i != axis ? r.u[i] : f for i = 1:r.dim]
+  return Rectangle(r.l, u), Rectangle(l, r.u)
+end
+
+function update_list(L::Vector{Rectangle}, f::Vector{Float64})
+  @info L
+  @info f
+  L̄, L = L, Vector{Rectangle}()
+  for Rᵢ in L̄
+    lᵢ, uᵢ = Rᵢ.l, Rᵢ.u
+    T = [Rᵢ]
+    for j = 1:length(f)
+      if lᵢ[j] < f[j] < uᵢ[j]
+        @info "anything?"
+        T̄ = Vector{Rectangle}()
+        for Rₜ in T
+          push!(T̄, split_rectangle(Rₜ, j, f[j])...)
+        end
+        T = T̄
+      end
+    end
+    push!(L, T...)
+  end
+  return L
+end
+
+#=
+=#
+function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
+  
+  # Problem with p objectives.
+  # Set k = 1, meaning the nondominated points will get projected 
+  # down to the objective {2, 3, ..., p}
+
+  k = 1
+
+  XE, YN = Vector{Dict{MOI.VariableIndex,Float64}}(), Vector{Vector{Float64}}()
+
+  solutions = ParetoSolution[]
+  
+  variables = MOI.get(model.inner, MOI.ListOfVariableIndices())
+  sense = MOI.get(model.inner, MOI.ObjectiveSense())
+  nbObj = MOI.output_dimension(model.f)
+  yI, yN = zeros(nbObj), zeros(nbObj)
+  δ = ifelse(sense == MOI.MIN_SENSE, -1, 1)
+
+  # Ideal and Nadir point estimation
+  for (i, f_i) in enumerate(MOI.Utilities.scalarize(model.f))
+    MOI.set(model.inner, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), f_i)
+    MOI.set(model.inner, MOI.ObjectiveSense(), sense)
+    @info sense
+    MOI.optimize!(model.inner)
+    X = Dict{MOI.VariableIndex,Float64}(
+      x => MOI.get(model.inner, MOI.VariablePrimal(), x) for
+      x in variables
+    )
+    yI[i] = MOI.Utilities.eval_variables(x -> X[x], f_i)
+    MOI.set(model.inner, MOI.ObjectiveSense(), ifelse(sense == MOI.MIN_SENSE, MOI.MAX_SENSE, MOI.MIN_SENSE))
+    MOI.optimize!(model.inner)
+    X = Dict{MOI.VariableIndex,Float64}(
+      x => MOI.get(model.inner, MOI.VariablePrimal(), x) for
+      x in variables
+    )
+    yN[i] = MOI.Utilities.eval_variables(x -> X[x], f_i)
+  end
+
+  proj(x::Vector{Float64}, axis::Int) = x[begin:end .!= axis]
+
+  volume(r::Rectangle, l::Vector{Float64}) = prod(r.u - l)
+
+  L = [Rectangle(proj(yI, k), proj(yN, k))]
+
+  SetType = ifelse(
+    sense == MOI.MIN_SENSE,
+    MOI.LessThan{Float64},
+    MOI.GreaterThan{Float64},
+  )
+
+  while !isempty(L)
+
+    Rᵢ = L[argmax(volume(Rᵢ, proj(yI, k)) for Rᵢ in L)]
+    lᵢ, uᵢ = Rᵢ.l, Rᵢ.u
+
+    # Solving the first stage model: P_k(ε)
+    # Set ε := uᵢ
+    ε = insert!(copy(uᵢ), k, 0.0)
+    ε_constraints = Dict{Int, Any}()
+
+    MOI.set(
+      model.inner, 
+      MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), 
+      getindex(MOI.Utilities.scalarize(model.f), k)
+    )
+    MOI.set(model.inner, MOI.ObjectiveSense(), sense)
+
+    for (i, f_i) in enumerate(MOI.Utilities.scalarize(model.f))
+      if i ≠ k
+        ε_constraints[i] = MOI.add_constraint(model.inner, f_i, SetType(ε[i] + δ))
+      end
+    end
+
+    MOI.optimize!(model.inner)
+    if MOI.get(model.inner, MOI.TerminationStatus()) == MOI.OPTIMAL
+
+      zₖ = MOI.get(model.inner, MOI.ObjectiveValue())
+
+      # Solving the second stage model: Q_k(ε, zₖ)
+      # Set objective sum(model.f)
+
+      MOI.set(
+        model.inner, 
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), 
+        sum(MOI.Utilities.scalarize(model.f))
+      )
+      MOI.set(model.inner, MOI.ObjectiveSense(), sense)
+  
+      # Constraint to eliminate weak dominance
+      zₖ_constraint = MOI.add_constraint(model.inner, getindex(MOI.Utilities.scalarize(model.f), k), MOI.EqualTo(zₖ))
+  
+      MOI.optimize!(model.inner)
+
+      for (i, ε_constraint) in ε_constraints
+        MOI.delete(model, ε_constraint)
+      end
+      MOI.delete(model, zₖ_constraint)
+
+      if MOI.get(model.inner, MOI.TerminationStatus()) == MOI.OPTIMAL
+        X = Dict{MOI.VariableIndex,Float64}(
+          x => MOI.get(model.inner, MOI.VariablePrimal(), x) for
+          x in variables
+        )
+        f = MOI.Utilities.eval_variables(x -> X[x], model.f)
+        f̄ = proj(f, k)
+        if f ∈ YN # solution already exists!
+        else # new solution!
+          @info f
+          push!(YN, f); push!(XE, X)
+					L = update_list(L, f̄)
+          @info "Length of L: $(length(L))"
+        end
+        remove_rect!(L, Rectangle(f̄, uᵢ))
+      else # Q is infeasible
+        remove_rect!(L, Rectangle(proj(yI, k), uᵢ))
+      end
+    else 
+      remove_rect!(L, Rectangle(proj(yI, k), uᵢ))
+    end
+    
+  end
+  
+  for (Xi, Yi) in zip(XE, YN)
+    push!(solutions, ParetoSolution(Xi, Yi))
+  end
+  
+  return MOI.OPTIMAL, solutions
+end

--- a/test/algorithms/KirlikSayin.jl
+++ b/test/algorithms/KirlikSayin.jl
@@ -1,0 +1,114 @@
+module TestKirlikSayin
+
+using Test
+using JuMP
+
+import HiGHS
+import MOO
+
+function run_tests()
+  for name in names(@__MODULE__; all = true)
+      if startswith("$name", "test_")
+          @testset "$name" begin
+              getfield(@__MODULE__, name)()
+          end
+      end
+  end
+  return
+end
+
+function test_knapsack_min_p3()
+  p = 3
+  n = 10
+  W = 2137.
+  C = Float64[
+    566 611 506 180 817 184 585 423 26 317
+    62 84 977 979 874 54 269 93 881 563
+    664 982 962 140 224 215 12 869 332 537
+  ]
+  w = Float64[557, 898, 148, 63, 78, 964, 246, 662, 386, 272]
+  model = Model(() -> MOO.Optimizer(HiGHS.Optimizer))
+  set_optimizer_attribute(model, MOO.Algorithm(), MOO.Lexicographic())
+  set_silent(model)
+  @variable(model, x[1:n], Bin)
+  @objective(model, Min, -C * x)
+  @constraint(model, sum(x) ≤ W)
+  optimize!(model)
+  X_E = Float64[
+    1 0 1 1 1 0 1 1 0 1
+    0 1 1 1 1 0 1 0 1 1
+    1 1 1 1 1 0 0 0 0 1
+    0 1 1 1 1 0 0 1 0 1
+    1 1 1 1 1 0 0 0 1 0
+    1 0 1 1 1 0 0 1 1 0
+    0 0 1 1 1 0 1 1 1 1
+  ]
+  Y_N = Float64[
+    -3394 -3817 -3408
+    -3042 -4627 -3189
+    -2997 -3539 -3509
+    -2854 -3570 -3714
+    -2706 -3857 -3304
+    -2518 -3866 -3191
+    -2854 -4636 -3076
+  ]
+  @test isapprox(
+    X_E, 
+    vcat([transpose(value.(x)) for i = 1:result_count(model)]...); atol = 1e-6
+  )
+  @test isapprox(
+    Y_N, 
+    vcat([transpose(objective_value(model, result=i)) for i = 1:result_count(model)]...); atol = 1e-6
+  )
+  return  
+end
+
+function test_knapsack_max_p3()
+  p = 3
+  n = 10
+  W = 2137.
+  C = Float64[
+    566 611 506 180 817 184 585 423 26 317
+    62 84 977 979 874 54 269 93 881 563
+    664 982 962 140 224 215 12 869 332 537
+  ]
+  w = Float64[557, 898, 148, 63, 78, 964, 246, 662, 386, 272]
+  model = Model(() -> MOO.Optimizer(HiGHS.Optimizer))
+  set_optimizer_attribute(model, MOO.Algorithm(), MOO.Lexicographic())
+  set_silent(model)
+  @variable(model, x[1:n], Bin)
+  @objective(model, Max, C * x)
+  @constraint(model, sum(x) ≤ W)
+  optimize!(model)
+  X_E = Float64[
+    1 0 1 1 1 0 1 1 0 1
+    0 1 1 1 1 0 1 0 1 1
+    1 1 1 1 1 0 0 0 0 1
+    0 1 1 1 1 0 0 1 0 1
+    1 1 1 1 1 0 0 0 1 0
+    1 0 1 1 1 0 0 1 1 0
+    0 0 1 1 1 0 1 1 1 1
+  ]
+  Y_N = Float64[
+    3394 3817 3408
+    3042 4627 3189
+    2997 3539 3509
+    2854 3570 3714
+    2706 3857 3304
+    2518 3866 3191
+    2854 4636 3076
+  ]
+  @test isapprox(
+    X_E, 
+    vcat([transpose(value.(x)) for i = 1:result_count(model)]...); atol = 1e-6
+  )
+  @test isapprox(
+    Y_N, 
+    vcat([transpose(objective_value(model, result=i)) for i = 1:result_count(model)]...); atol = 1e-6
+  )
+  return
+end
+
+TestKirlikSayin.run_tests()
+
+end


### PR DESCRIPTION
Link for the algorithm [1]: https://doi.org/10.1016/j.ejor.2013.08.001

You are able to solve multi-objective discrete problems with 2 or more objectives.

For now, I did not add any attributes. `ObjectiveTolerance` is probably what is defined as \delta and another attribute for the choice of objective k can be defined. For now, I am using \delta = 1 and k = 1. I think user can have the choice for k.

There is a bug right now. My own implementation without MOI is able to find all non-dominated points. Also, I have not accounted for maximization objectives but should be simple.

Test contain problem instances from the paper linked above. I am planning to add tests for 4-objective knapsack, 5-objective knapsack and 3-objective assignment problem.

[1] Gokhan Kirlik and Serpil Sayin. A new algorithm for generating all nondominated solutions of multiobjective discrete optimization problems. European Journal of Operational Research, 232:479–488, 2 2014.